### PR TITLE
Link to unpkg instead of rawgit

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 Load the latest version of ```glsl-canvas.js``` on your page by adding this line to your HTML:
 ```html
-<script type="text/javascript" src="https://rawgit.com/actarian/glsl-canvas/master/dist/glsl-canvas.min.js"></script>
+<script type="text/javascript" src="https://unpkg.com/glsl-canvas-js/dist/glsl-canvas.min.js"></script>
 ```
 
 *With npm*


### PR DESCRIPTION
RawGit is being sunset… https://rawgit.com

Using unpkg also means you can specify a version, like https://unpkg.com/glsl-canvas-js@0.1.5/dist/glsl-canvas.min.js