### PR TITLE
added support for `uniform1fv`

### DIFF
--- a/src/uniforms/uniforms.ts
+++ b/src/uniforms/uniforms.ts
@@ -81,6 +81,15 @@ export class Uniform {
 					}
 				}
 				break;
+			case UniformMethod.Uniform1fv:
+				this.apply = (gl: WebGLRenderingContext | WebGL2RenderingContext, program: WebGLProgram) => {
+					if (this.dirty) {
+						gl.useProgram(program);
+						const location = gl.getUniformLocation(program, this.key);
+						(gl as any)[this.method].apply(gl, [location].concat([this.values]));
+					}
+				}
+				break;
 			default:
 				this.apply = (gl: WebGLRenderingContext | WebGL2RenderingContext, program: WebGLProgram) => {
 					if (this.dirty) {


### PR DESCRIPTION
Hi,

I noticed that when passing arbitrary length array uniforms the library is throwing an error.
```js
glsl.setUniform('u_rands', 1.0,0.2,0.3,1,0.5); 
```

 I looked around and found that `uniform1fv` method expects a single argument with the array:
https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/uniform
```
void gl.uniform1fv(location, value);
```
Best regards,
Adrian

